### PR TITLE
Added code to set a min and max limit on dates

### DIFF
--- a/src/app/components/installations/ScheduleInstallation.jsx
+++ b/src/app/components/installations/ScheduleInstallation.jsx
@@ -68,6 +68,10 @@ export default class ScheduleInstallation extends React.Component {
   constructor(props) {
     super(props);
 
+    const minDate = new Date();
+    const maxDate = new Date();
+    maxDate.setFullYear(maxDate.getFullYear() + 1);
+
     this.state = {
       tabA: true,
       tabB: false,
@@ -94,6 +98,8 @@ export default class ScheduleInstallation extends React.Component {
       installedDate: {},
       contractorId: '',
       installerName: '',
+      minDate: minDate,
+      maxDate: maxDate,
 
       // Error messages for each input field
       fnameErr: '',
@@ -163,6 +169,7 @@ export default class ScheduleInstallation extends React.Component {
           let installation = JSON.parse(httpRequest.responseText).installation;
           // Format time
           var tempDateTime = new Date(installation.installationDateTime);
+          var minDate = new Date(2000, 0, 1);
 
           _this.setState({
             // salesNumber: sale.salesNumber,
@@ -184,6 +191,7 @@ export default class ScheduleInstallation extends React.Component {
             installedDate: tempDateTime ? tempDateTime : '',
             contractorId: installation.installerId ? installation.installerId : '',
             installerName: installation.installerName ? installation.installerName : '',
+            minDate: minDate,
           });
         }
       };
@@ -974,6 +982,8 @@ export default class ScheduleInstallation extends React.Component {
                     container="inline"
                     value={this.state.installedDate}
                     onChange={this.handleDateChange.bind(this, "installedDate")}
+                    minDate={this.state.minDate}
+                    maxDate={this.state.maxDate}
                   />
                   <div style={{color:"red", float: "left"}}>{this.state.installedDateErr}</div>
                 </div>

--- a/src/app/components/sales/NewSale.jsx
+++ b/src/app/components/sales/NewSale.jsx
@@ -28,6 +28,11 @@ export default class NewSale extends React.Component {
 
   constructor(props) {
     super(props);
+
+    const minDate = new Date();
+    const maxDate = new Date();
+    maxDate.setFullYear(maxDate.getFullYear() + 1);
+
     this.state = {
       tabA: true,
       tabB: false,
@@ -53,6 +58,8 @@ export default class NewSale extends React.Component {
       applicationNumber: '',
       programType: '',
       dateSigned: new Date(),
+      minDate: minDate,
+      maxDate: maxDate,
 
       // Unknown data
       homeownerSignature: '',
@@ -110,6 +117,7 @@ export default class NewSale extends React.Component {
           let sale = JSON.parse(httpRequest.responseText).sale;
           // Format time
           var tempDateTime = new Date(sale.installationDateTime);
+          var minDate = new Date(2000, 0, 1);
 
           _this.setState({
             salesNumber: sale.salesNumber,
@@ -129,6 +137,7 @@ export default class NewSale extends React.Component {
             installationTime: tempDateTime ? tempDateTime : '',
             notes: sale.notes ? sale.notes : '',
             salesRepId: sale.salesRepId ? sale.salesRepId : '',
+            minDate: minDate,
           });
         }
       };
@@ -744,6 +753,8 @@ export default class NewSale extends React.Component {
                 <DatePicker
                   hintText="2017-08-20" container="inline"
                   floatingLabelText="Installation Date"
+                  minDate={this.state.minDate}
+                  maxDate={this.state.maxDate}
                   value={this.state.installationDate}
                   onChange={this.handleDateChange.bind(this, "installationDate")}
                 />
@@ -873,6 +884,8 @@ export default class NewSale extends React.Component {
                 hintText="2017-08-20"
                 container="inline"
                 floatingLabelText="Installation Date"
+                minDate={this.state.minDate}
+                maxDate={this.state.maxDate}
                 style={{ display: "inline-block", width: "200px" }}
                 value={this.state.installationDate}
                 onChange={this.handleTextChange.bind(this, "installationDate")}
@@ -1030,6 +1043,8 @@ export default class NewSale extends React.Component {
                 <DatePicker
                   hintText="2017-08-20" container="inline"
                   floatingLabelText="Installation Date"
+                  minDate={this.state.minDate}
+                  maxDate={this.state.maxDate}
                   value={this.state.installationDate}
                   onChange={this.handleDateChange.bind(this, "installationDate")}
                 />


### PR DESCRIPTION
Should fix #52.
Set min (today's date) and max (1 year from today's date) limits on all date picker components. Currently, there is not way to apply the same restraints to the time picker components.

EDIT: Updated the PR; Now, when creating a new sale/installation, the minDate is set to today's date and the maxDate is set to 1 year from now. When editing a sale/installation, the minDate is set to today's date minus 5 years and the maxDate remains as is (1 year from now).

EDIT 2: Set the minDate date for Editing to Jan. 1, 2000. The rest remains the same.