### PR TITLE
Fixes

### DIFF
--- a/src/app/components/installations/installation-table/InstallationTable.jsx
+++ b/src/app/components/installations/installation-table/InstallationTable.jsx
@@ -85,6 +85,10 @@ export default class InstallationTable extends React.Component {
     }
   }
 
+  handleResume = (status) => {
+    console.log('in resume');
+    console.log(status);
+  }
   sortClickHandler(cellDataKey) {
     var sortDir = this.state.sortDir;
     var sortBy = camelize(cellDataKey);
@@ -137,6 +141,37 @@ export default class InstallationTable extends React.Component {
     }
   }
 
+  getToolbarActionButtons() {
+    let status = this.state.filteredDataList[this.state.selectedNum].status;
+    console.log(status);
+    return (
+      <ToolbarGroup>
+        <ToolbarSeparator />
+        { status == "Documented" || status == "Installed" || status == "Customer signed" || status == "Installer signed" ?
+          <RaisedButton
+            label="Resume"
+            secondary={true}
+            onTouchTap={(e) => {e.preventDefault(); this.handleResume(status)}}
+          />
+        : null }
+        <RaisedButton
+          label="Edit"
+          primary={true}
+          onTouchTap={(e) => {e.preventDefault(); this.props.editClickHandler("edit", this.state.selectedId, "editInstallation")}}
+        />
+        <RaisedButton
+          label="Details"
+          primary={true}
+          onTouchTap={(e) => {e.preventDefault(); this.handleOpen()}}
+        />
+        <RaisedButton
+          label="Cancel"
+          primary={true}
+          onTouchTap={(e) => {e.preventDefault(); this.handleCancel()}}
+        />
+      </ToolbarGroup>
+    );
+  }
   render() {
 
     return (
@@ -145,24 +180,7 @@ export default class InstallationTable extends React.Component {
           <ToolbarGroup>
             <ToolbarTitle text="View All Installations" className="mainFont" />
             {this.state.currentSelected ?
-              <ToolbarGroup>
-                <ToolbarSeparator />
-                <RaisedButton
-                  label="Edit"
-                  primary={true}
-                  onTouchTap={(e) => {e.preventDefault(); this.props.editClickHandler("edit", this.state.selectedId, "editInstallation")}}
-                />
-                <RaisedButton
-                  label="Details"
-                  primary={true}
-                  onTouchTap={(e) => {e.preventDefault(); this.handleOpen()}}
-                />
-                <RaisedButton
-                  label="Cancel"
-                  primary={true}
-                  onTouchTap={(e) => {e.preventDefault(); this.handleCancel()}}
-                />
-              </ToolbarGroup>
+              this.getToolbarActionButtons()
             : null }
           </ToolbarGroup>
         </Toolbar>

--- a/src/app/components/installations/installation-table/InstallationTable.jsx
+++ b/src/app/components/installations/installation-table/InstallationTable.jsx
@@ -164,11 +164,15 @@ export default class InstallationTable extends React.Component {
           primary={true}
           onTouchTap={(e) => {e.preventDefault(); this.handleOpen()}}
         />
-        <RaisedButton
-          label="Cancel"
-          primary={true}
-          onTouchTap={(e) => {e.preventDefault(); this.handleCancel()}}
-        />
+        { status == "Cancelled" ?
+          null
+        :
+          <RaisedButton
+            label="Cancel"
+            primary={true}
+            onTouchTap={(e) => {e.preventDefault(); this.handleCancel()}}
+          />
+        }
       </ToolbarGroup>
     );
   }

--- a/src/app/components/sales/create-sale/sale-form/SaleForm.jsx
+++ b/src/app/components/sales/create-sale/sale-form/SaleForm.jsx
@@ -611,6 +611,11 @@ export default class SaleForm extends React.Component {
 
           // Passing the new sale object to the next component (DocuSign form)
           _this.props.handleSaleNext(saleObject);
+        } else if(this.status == 409) {
+          let obj = JSON.parse(request.responseText);
+          if(obj.errorMessage) {
+            _this.props.handleSnackbar(obj.errorMessage, true);
+          }
         } else {
           _this.props.handleSnackbar('', true, this.status);
         }

--- a/src/app/components/sales/sale-table/SaleTable.jsx
+++ b/src/app/components/sales/sale-table/SaleTable.jsx
@@ -164,11 +164,15 @@ export default class SaleTable extends React.Component {
           primary={true}
           onTouchTap={(e) => {e.preventDefault(); this.handleOpen()}}
         />
-        <RaisedButton
-          label="Cancel"
-          primary={true}
-          onTouchTap={(e) => {e.preventDefault(); this.handleCancel()}}
-        />
+        { status == "Cancelled" ?
+          null
+        :
+          <RaisedButton
+            label="Cancel"
+            primary={true}
+            onTouchTap={(e) => {e.preventDefault(); this.handleCancel()}}
+          />
+        }
       </ToolbarGroup>
     );
   }

--- a/src/app/components/sales/sale-table/SaleTable.jsx
+++ b/src/app/components/sales/sale-table/SaleTable.jsx
@@ -85,6 +85,11 @@ export default class SaleTable extends React.Component {
     }
   }
 
+  handleResume = (status) => {
+    console.log('in handle resume');
+    console.log(status);
+  }
+
   sortClickHandler(cellDataKey) {
     var sortDir = this.state.sortDir;
     var sortBy = camelize(cellDataKey);
@@ -137,6 +142,37 @@ export default class SaleTable extends React.Component {
     }
   }
 
+  getToolbarActionButtons = () => {
+    let status = this.state.filteredDataList[this.state.selectedNum].status;
+    return (
+      <ToolbarGroup>
+        <ToolbarSeparator />
+        { status == "Created" || status == "Signed" ?
+        <RaisedButton
+          label="Resume"
+          secondary={true}
+          onTouchTap={(e) => {e.preventDefault(); this.handleResume(status)}}
+        />
+        : null }
+        <RaisedButton
+          label="Edit"
+          primary={true}
+          onTouchTap={(e) => {e.preventDefault(); this.props.editClickHandler("edit", this.state.selectedId, "editSale")}}
+        />
+        <RaisedButton
+          label="Details"
+          primary={true}
+          onTouchTap={(e) => {e.preventDefault(); this.handleOpen()}}
+        />
+        <RaisedButton
+          label="Cancel"
+          primary={true}
+          onTouchTap={(e) => {e.preventDefault(); this.handleCancel()}}
+        />
+      </ToolbarGroup>
+    );
+  }
+
   render() {
     return (
       <div className="allCustomers">
@@ -144,24 +180,7 @@ export default class SaleTable extends React.Component {
           <ToolbarGroup>
             <ToolbarTitle text="View All Sales" className="mainFont" />
             {this.state.currentSelected ?
-              <ToolbarGroup>
-                <ToolbarSeparator />
-                <RaisedButton
-                  label="Edit"
-                  primary={true}
-                  onTouchTap={(e) => {e.preventDefault(); this.props.editClickHandler("edit", this.state.selectedId, "editSale")}}
-                />
-                <RaisedButton
-                  label="Details"
-                  primary={true}
-                  onTouchTap={(e) => {e.preventDefault(); this.handleOpen()}}
-                />
-                <RaisedButton
-                  label="Cancel"
-                  primary={true}
-                  onTouchTap={(e) => {e.preventDefault(); this.handleCancel()}}
-                />
-              </ToolbarGroup>
+              this.getToolbarActionButtons()
             : null }
           </ToolbarGroup>
         </Toolbar>


### PR DESCRIPTION
- Added "Resume" buttons to "View all Sales/Installations" for incomplete statuses.
- display snackBar for the duplicate enbridge numbers
- hide Cancel buttons for already cancelled Sales/Installations